### PR TITLE
Improve scripts

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,15 +1,33 @@
+configDir='../config'
+
 # intall oh my zsh and plugins for zsh
+echo "Installing OH-MY-ZSH\n"
 sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"
+echo "\nInstalling Plugin\ns"
 git clone https://github.com/zsh-users/zsh-syntax-highlighting.git ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting
 git clone https://github.com/zsh-users/zsh-autosuggestions ${ZSH_CUSTOM:-~/.oh-my-zsh/custom}/plugins/zsh-autosuggestions
 
 # install neovim, nvm and yay package manager for managing AUR packages
-sudo pacman -S neovim python-pynvim nvm yay
+echo "Installing Packages"
+sudo pacman -Syu
+sudo pacman -S neovim python-pynvim nodejs npm yay
 yay -S oh-my-posh-bin awesome-git picom-git rofi github-cli
 # create symbolic links for .zshrc, .gitconifg
-rm ~/.zshrc && ln -s ~/.dotfiles/config/zsh/.zshrc ~/.zshrc
+if [ -e ~/.zshrc ]; then
+  echo "ZSH config found"
+  echo "Moveing .zshrc to .zshrc.bak"
+  mv ~/.zshrc ~/.zshrc.bak
+  ln -s $configDir/zsh/.zshrc ~/.zshrc
+else
+  ln -s $configDir/zsh/.zshrc ~/.zshrc
+fi
 
 # create symlink for neofetch
-rm ~/.config/neofetch/config.conf && ln ~/.dotfiles/config/neofetch/config.conf ~/.config/neofetch/
-
-exec zsh
+if [ -e ~/.config/neofetch/config.conf ]; then
+  echo "Neofetch config found"
+  echo "Moveing neofetch/config.conf to neofetch/config.conf.bak"
+  mv ~/.config/neofetch/config.conf ~/.config/neofetch/config.conf.bak
+  ln $configDir/neofetch/config.conf ~/.config/neofetch/
+else
+  ln $configDir/neofetch/config.conf ~/.config/neofetch/
+fi

--- a/scripts/symlink.sh
+++ b/scripts/symlink.sh
@@ -1,8 +1,17 @@
+configDir='../config'
+
 # create symbolic link for kitty config
-rm .config/kitty/kitty.conf && ln -s ~/.dotfiles/config/kitty/kitty.conf ~/.config/kitty/
+if [ -e ~/.config/kitty/kitty.conf ]; then
+  echo "Kitty config found"
+  echo "Moving kitty.conf to kitty.conf.bak"
+  mv ~/.config/kitty/kitty.conf ~/.config/kitty/kitty.conf.bak
+  ln -s ~/.dotfiles/config/kitty/kitty.conf ~/.config/kitty/
+else
+  ln -s ~/.dotfiles/config/kitty/kitty.conf ~/.config/kitty/
+fi
 # create symlinks for awesome, picom
 sudo rm -r ~/.config/awesome/themes/multicolor/icons
-ln -s ~/.dotfiles/config/awesome/rc.lua ~/.config/awesome/
-ln -s ~/.dotfiles/config/awesome/theme-personal.lua ~/.config/awesome/themes/multicolor/
-ln -s ~/.dotfiles/config/awesome/icons ~/.config/awesome/themes/multicolor/
-ln -s ~/.dotfiles/config/picom/picom.conf ~/.config/picom/
+ln -s $configDir/awesome/rc.lua ~/.config/awesome/
+ln -s $configDir/awesome/theme-personal.lua ~/.config/awesome/themes/multicolor/
+ln -s $configDir/awesome/icons ~/.config/awesome/themes/multicolor/
+ln -s $configDir/picom/picom.conf ~/.config/picom/


### PR DESCRIPTION
Improve the `install.sh` and `symlinks.sh`

**Bug**: The config path was broken

> If the user saves this GitHub repo in the Downloads folder then the `install.sh` script is not going to work because the path in the `install.sh` was `~/.dotfiles` which is wrong.
> 
> **Fix**:
> 
> I fix the bug by going back one directory and then into the `.config` directory.